### PR TITLE
fix: correct Read() mock index and pass buf to Called()

### DIFF
--- a/random/mock.go
+++ b/random/mock.go
@@ -63,7 +63,7 @@ func (m *Mock) Perm(n int) []int {
 }
 
 func (m *Mock) Read(buf []byte) (int, error) {
-	args := m.Called()
+	args := m.Called(buf)
 	outBuf := args.Get(0).([]byte)
-	return copy(buf, outBuf), args.Error(2)
+	return copy(buf, outBuf), args.Error(1)
 }


### PR DESCRIPTION
BUG-1: random/mock.go Read() used args.Error(2) for a (int, error) signature, causing an index out of bounds panic. Changed to args.Error(1).

Also pass buf argument to m.Called(buf) so consumers can assert on the input buffer in their mock expectations.